### PR TITLE
Migrated to last version of Battlenet API

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -46,7 +46,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://'.$this->getRegion().'.api.battle.net/account/user', [
+        $response = $this->getHttpClient()->get('https://'.$this->getRegion().'.battle.net/oauth/userinfo', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],


### PR DESCRIPTION
The url for getting user details has changed from https://{region}.api.battle.net/account/user to https://{region}.battle.net/oauth/userinfo

See migration guide: https://develop.battle.net/documentation/guides/migration-guide